### PR TITLE
test(server): mock database in server tests

### DIFF
--- a/server/server.test.js
+++ b/server/server.test.js
@@ -1,4 +1,38 @@
 const request = require('supertest');
+
+const mockRows = [
+    {
+        name: 'Community Hub',
+        description: 'Support services',
+        address: '123 Main St',
+        latitude: 45.4215,
+        longitude: -75.6972,
+        url: 'https://example.com/hub'
+    },
+    {
+        name: 'No Coordinates Resource',
+        description: 'Phone support',
+        address: '456 Side St',
+        latitude: null,
+        longitude: null,
+        url: 'https://example.com/phone'
+    }
+];
+
+jest.mock('pg', () => ({
+    Pool: jest.fn(() => ({
+        query: jest.fn((sql) => {
+            if (sql.includes('WHERE latitude IS NOT NULL AND longitude IS NOT NULL')) {
+                return Promise.resolve({
+                    rows: mockRows.filter((row) => row.latitude !== null && row.longitude !== null)
+                });
+            }
+
+            return Promise.resolve({ rows: mockRows });
+        })
+    }))
+}));
+
 const app = require('./server');
 
 describe('GET /', () => {


### PR DESCRIPTION
## Why
The existing server tests require a live local Postgres instance, so they fail in CI and on clean contributor machines even though the Express routes themselves are testable in isolation.

## What changed
- mock the `pg` `Pool` in `server/server.test.js`
- return deterministic rows for both all-location and with-location queries
- keep route assertions intact while removing the external database dependency from the unit test suite

## Reproduction evidence
Before:
```text
FAIL ./server.test.js
GET /cards › should return 200 and an array of all cards
Expected: 200
Received: 500
```

After:
```text
PASS ./server.test.js
Tests: 8 passed, 8 total
```

Closes #24
